### PR TITLE
Stop a console window from appearing

### DIFF
--- a/lib/find_process.js
+++ b/lib/find_process.js
@@ -79,7 +79,7 @@ const finders = {
       const cmd = 'WMIC path win32_process get Name,Processid,ParentProcessId,Commandline'
       const lines = []
 
-      const proc = utils.spawn('cmd', ['/c', cmd], { detached: false })
+      const proc = utils.spawn('cmd', ['/c', cmd], { detached: false, windowsHide: true })
       proc.stdout.on('data', data => {
         lines.push(data.toString())
       })


### PR DESCRIPTION
In Windows, when called from pm2, a console window appears very briefly while the spawn command executes.  node 8.x+ has an option to
hide that window, so this takes advantage of that.